### PR TITLE
Pj3 done. All 113 tests passed.

### DIFF
--- a/src/Makefile.build
+++ b/src/Makefile.build
@@ -63,6 +63,9 @@ userprog_SRC += userprog/tss.c		# TSS management.
 
 # No virtual memory code yet.
 #vm_SRC = vm/file.c			# Some file.
+# /* === ADD START p3q1 ===*/
+vm_SRC  = vm/page.c         # supplementary page table
+# /* === ADD END p3q1 ===*/
 
 # Filesystem code.
 filesys_SRC  = filesys/filesys.c	# Filesystem core.

--- a/src/Makefile.build
+++ b/src/Makefile.build
@@ -69,6 +69,11 @@ vm_SRC  = vm/page.c         # supplementary page table
 # /* === ADD START p3q3 ===*/
 vm_SRC  += vm/mmap.c         # memory mapped file
 # /* === ADD END p3q3 ===*/
+# /* === ADD START p3q4 ===*/
+vm_SRC  += vm/frame.c	     # frame
+vm_SRC  += vm/swap.c         # swap partition
+# /* === ADD END p3q4 ===*/
+
 
 # Filesystem code.
 filesys_SRC  = filesys/filesys.c	# Filesystem core.

--- a/src/Makefile.build
+++ b/src/Makefile.build
@@ -66,6 +66,9 @@ userprog_SRC += userprog/tss.c		# TSS management.
 # /* === ADD START p3q1 ===*/
 vm_SRC  = vm/page.c         # supplementary page table
 # /* === ADD END p3q1 ===*/
+# /* === ADD START p3q3 ===*/
+vm_SRC  += vm/mmap.c         # memory mapped file
+# /* === ADD END p3q3 ===*/
 
 # Filesystem code.
 filesys_SRC  = filesys/filesys.c	# Filesystem core.

--- a/src/threads/init.c
+++ b/src/threads/init.c
@@ -38,6 +38,13 @@
 #include "filesys/fsutil.h"
 #endif
 
+/* === ADD START p3q4 ===*/
+#ifdef VM
+#include "vm/swap.h"
+#endif
+/* === ADD END p3q4 ===*/
+
+
 /* Page directory with kernel mappings only. */
 uint32_t *init_page_dir;
 
@@ -126,6 +133,15 @@ main (void)
   locate_block_devices ();
   filesys_init (format_filesys);
 #endif
+
+/* === ADD START p3q4 ===*/
+#ifdef VM
+  locate_block_devices ();
+  swap_table_init();
+#endif
+/* === ADD END p3q4 ===*/
+
+
 
   printf ("Boot complete.\n");
   

--- a/src/threads/palloc.c
+++ b/src/threads/palloc.c
@@ -200,7 +200,7 @@ palloc_free_multiple (void *pages, size_t page_cnt)
   bitmap_set_multiple (pool->used_map, page_idx, page_cnt, false);
 
   /* === ADD START p3q4 ===*/
-  if ( flags & PAL_USER && page_cnt == 1) {
+  if ( page_from_pool (&user_pool, pages) && page_cnt == 1) {
     struct frame* cur_frame = find_frame( pages );
     ASSERT( cur_frame != NULL );
     if( is_victim(cur_frame) ) {

--- a/src/threads/synch.c
+++ b/src/threads/synch.c
@@ -241,6 +241,11 @@ lock_acquire (struct lock *lock)
   if (!thread_mlfqs) {
     /* === ADD END jihun q3 ===*/
 
+/* === ADD START p3q4 ===*/
+#ifndef VM
+// TODO for now, we disable priority donation for VM project.
+//      but the problem should further be resolved.
+/* === ADD END p3q4 ===*/
     if (lock->holder != NULL) {  // donation needed
 
       cur->lock_acquiring = lock;
@@ -252,6 +257,9 @@ lock_acquire (struct lock *lock)
 
       donate_priority(cur, cur->priority);
     }
+/* === ADD START p3q4 ===*/
+#endif
+/* === ADD END p3q4 ===*/
 
     /* === ADD START jihun q3 ===*/
   }

--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -597,9 +597,6 @@ void donate_priority (struct thread* cur, int priorityToDonate) {
   ASSERT( cur->lock_acquiring != NULL );
 
   while( cur->lock_acquiring != NULL ){
-    /* === ADD START p3q4 ===*/
-    if( cur->lock_acquiring->holder == NULL ){ break; }
-    /* === ADD END p3q4 ===*/
     ASSERT( cur->lock_acquiring->holder != NULL );
     cur = cur->lock_acquiring->holder;
     // isPreemptRequired=false, isCalledByDonation=true

--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -20,6 +20,11 @@
 #include "threads/fixed_point_arithmetic.h"
 /* === ADD END jihun ===*/
 
+/* === ADD START p3q4 ===*/
+#include "vm/frame.h"
+#include "vm/swap.h"
+/* === ADD END p3q4===*/
+
 #ifdef USERPROG
 #include "userprog/process.h"
 #endif
@@ -116,6 +121,11 @@ static bool is_thread (struct thread *) UNUSED;
   /* === ADD START jinho q1 ===*/
   list_init( &sleep_list );
   /* === ADD END jinho q1 ===*/
+
+  /* === ADD START p3q4 ===*/
+  frame_table_init();
+  swap_table_init(); // todo param size?
+  /* === ADD END p3q4 ===*/
 
   /* Set up a thread structure for the running thread. */
   initial_thread = running_thread ();

--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -124,7 +124,6 @@ static bool is_thread (struct thread *) UNUSED;
 
   /* === ADD START p3q4 ===*/
   frame_table_init();
-  swap_table_init(); // todo param size?
   /* === ADD END p3q4 ===*/
 
   /* Set up a thread structure for the running thread. */

--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -597,6 +597,9 @@ void donate_priority (struct thread* cur, int priorityToDonate) {
   ASSERT( cur->lock_acquiring != NULL );
 
   while( cur->lock_acquiring != NULL ){
+    /* === ADD START p3q4 ===*/
+    if( cur->lock_acquiring->holder == NULL ){ break; }
+    /* === ADD END p3q4 ===*/
     ASSERT( cur->lock_acquiring->holder != NULL );
     cur = cur->lock_acquiring->holder;
     // isPreemptRequired=false, isCalledByDonation=true

--- a/src/threads/thread.h
+++ b/src/threads/thread.h
@@ -9,6 +9,11 @@
 #include "threads/synch.h"
 /* === ADD END jinho q2-2 ===*/
 
+/* === ADD START p3q1 ===*/
+#include <hash.h>
+/* === ADD END p3q1 ===*/
+
+
 /* States in a thread's life cycle. */
 enum thread_status
   {
@@ -154,6 +159,11 @@ struct thread
     /* === ADD START jihun p2q3 ===*/
     struct file *current_file;
     /* === ADD END jihun p2q3 ===*/
+
+    /* === ADD START jihun p3q1 ===*/
+    struct hash pmap;
+    /* === ADD END jihun p3q1 ===*/
+
 
 #ifdef USERPROG
     /* Owned by userprog/process.c. */

--- a/src/threads/thread.h
+++ b/src/threads/thread.h
@@ -164,6 +164,9 @@ struct thread
     struct hash pmap;
     /* === ADD END jihun p3q1 ===*/
 
+    /* === ADD START p3q3 ===*/
+    struct list mmap_list;
+    /* === ADD END p3q3 ===*/
 
 #ifdef USERPROG
     /* Owned by userprog/process.c. */

--- a/src/userprog/exception.c
+++ b/src/userprog/exception.c
@@ -209,6 +209,8 @@ static bool handle_page_fault(struct pme* fault_pme) {
   /* === ADD START p3q3 ===*/
   if( fault_pme == NULL )
   {
+    // NOTE : If fault_pme is NULL, and handler is being entered, it means that
+    //        the fault has occured in stack area access.
     // NOTE : We reference from IA32 architecture, which lets push instruction
     //        to push at most 32 bytes per a single instruction. Thus, if a
     //        memory reference which refers to region lower than esp-32,

--- a/src/userprog/exception.c
+++ b/src/userprog/exception.c
@@ -237,6 +237,7 @@ static bool handle_page_fault(struct pme* fault_pme, void* fault_addr, struct in
 
   struct mmap_meta* mmeta;
   switch ( fault_pme->type ) {
+    // ========================================================= //
     case PME_NULL: break;
     // ========================================================= //
     case PME_EXEC:
@@ -264,7 +265,8 @@ static bool handle_page_fault(struct pme* fault_pme, void* fault_addr, struct in
       break;
     // ========================================================= //
 //    case PME_SWAP:
-//      // todo swap
+//      // todo swap, swap in
+//      // change load status // this means our swap algorithm has worked.
 //      break;
     default: success = false;
   }

--- a/src/userprog/exception.c
+++ b/src/userprog/exception.c
@@ -11,6 +11,7 @@
 #include "userprog/process.h"
 #include "threads/vaddr.h"
 #include "vm/page.h"
+#include "threads/palloc.h"
 /* === ADD END p3q1 ===*/
 
 /* Number of page faults processed. */
@@ -20,11 +21,11 @@ static void kill (struct intr_frame *);
 static void page_fault (struct intr_frame *);
 
 /* === ADD START p3q1 ===*/
-static bool handle_page_fault (struct pme*);
+static bool handle_page_fault (struct pme*, void*, struct intr_frame*);
 /* === ADD END p3q1 ===*/
-/* === ADD START p3q3 ===*/
+/* === ADD START p3q2 ===*/
 static void grow_stack(void*);
-/* === ADD END p3q3 ===*/
+/* === ADD END p3q2 ===*/
 
 /* Registers handlers for interrupts that can be caused by user
    programs.
@@ -177,7 +178,7 @@ page_fault (struct intr_frame *f)
 
   // NOTE : it is admissible for page fault handler to
   //        receive pme => NULL
-  if( !handle_page_fault( fault_pme ) ){
+  if( !handle_page_fault( fault_pme, fault_addr, f ) ){
     exit(-1);
   }
 
@@ -205,8 +206,8 @@ page_fault (struct intr_frame *f)
 }
 
 /* === ADD START p3q1 ===*/
-static bool handle_page_fault(struct pme* fault_pme) {
-  /* === ADD START p3q3 ===*/
+static bool handle_page_fault(struct pme* fault_pme, void* fault_addr, struct intr_frame *f ) {
+  /* === ADD START p3q2 ===*/
   if( fault_pme == NULL )
   {
     // NOTE : We reference from IA32 architecture, which lets push instruction
@@ -219,7 +220,7 @@ static bool handle_page_fault(struct pme* fault_pme) {
     }
     else { return false; }
   }
-  /* === ADD END p3q3 ===*/
+  /* === ADD END p3q2 ===*/
 
   ASSERT( fault_pme != NULL );
   uint8_t *kpage = palloc_get_page (PAL_USER);
@@ -256,7 +257,7 @@ static bool handle_page_fault(struct pme* fault_pme) {
 }
 /* === ADD END p3q1 ===*/
 
-/* === ADD START p3q3 ===*/
+/* === ADD START p3q2 ===*/
 static void grow_stack(void *fault_addr)
 {
   uint8_t *kpage = palloc_get_page (PAL_USER | PAL_ZERO);
@@ -279,4 +280,4 @@ static void grow_stack(void *fault_addr)
 
   pmap_set_pme( &(thread_current()->pmap), pme_to_alloc );
 }
-/* === ADD END p3q3 ===*/
+/* === ADD END p3q2 ===*/

--- a/src/userprog/exception.c
+++ b/src/userprog/exception.c
@@ -15,6 +15,7 @@
 /* === ADD END p3q1 ===*/
 /* === ADD START p3q3 ===*/
 #include "vm/mmap.h"
+#include "vm/swap.h"
 /* === ADD END p3q3 ===*/
 
 
@@ -210,6 +211,9 @@ page_fault (struct intr_frame *f)
 }
 
 /* === ADD START p3q1 ===*/
+// NOTE: 1. load data
+//       2. install page
+//       3. update pme (to loaded)
 static bool handle_page_fault(struct pme* fault_pme, void* fault_addr, struct intr_frame *f ) {
   /* === ADD START p3q2 ===*/
 
@@ -264,10 +268,16 @@ static bool handle_page_fault(struct pme* fault_pme, void* fault_addr, struct in
       fault_pme-> load_status = true;
       break;
     // ========================================================= //
-//    case PME_SWAP:
-//      // todo swap, swap in
-//      // change load status // this means our swap algorithm has worked.
-//      break;
+    case PME_SWAP:
+      // swap in
+      swap_in( fault_pme->pme_swap_index, kpage );
+      if ( ! install_page (fault_pme->vaddr, kpage, fault_pme->write_permission) ) {
+        success = false; break;
+      }
+      // load success
+      fault_pme-> load_status = true;
+      break;
+    // ========================================================= //
     default: success = false;
   }
 

--- a/src/userprog/process.c
+++ b/src/userprog/process.c
@@ -22,10 +22,14 @@
 /* === ADD END jinho p2q2 ===*/
 /* === ADD START p3q1 ===*/
 #include "vm/page.h"
-/* === ADD END p3q3 ===*/
-/* === ADD START p3q1 ===*/
+/* === ADD END p3q1 ===*/
+/* === ADD START p3q3 ===*/
 #include "vm/mmap.h"
 /* === ADD END p3q3 ===*/
+/* === ADD START p3q4 ===*/
+#include "vm/frame.h"
+/* === ADD END p3q4 ===*/
+
 
 
 static thread_func start_process NO_RETURN;
@@ -714,7 +718,6 @@ setup_stack (void **esp)
 /* === DEL START p3q2 ===*/
 //static bool
 /* === DEL END p3q2 ===*/
-//* === ADD START p3q2 ===*/
 bool
 install_page (void *upage, void *kpage, bool writable)
 {
@@ -722,6 +725,22 @@ install_page (void *upage, void *kpage, bool writable)
 
   /* Verify that there's not already a page at that virtual
      address, then map our page there. */
-  return (pagedir_get_page (t->pagedir, upage) == NULL
+
+  /* === DEL START p3q4 ===*/
+//  return (pagedir_get_page (t->pagedir, upage) == NULL
+//          && pagedir_set_page (t->pagedir, upage, kpage, writable));
+  /* === DEL END p3q4 ===*/
+
+  /* === ADD START p3q4 ===*/
+  bool success = (pagedir_get_page (t->pagedir, upage) == NULL
           && pagedir_set_page (t->pagedir, upage, kpage, writable));
+
+  if( success ) {
+    struct frame* f = find_frame( kpage );
+    ASSERT( f != NULL );
+    install_vaddr_to_frame( f, upage );
+  }
+  return success;
+  /* === ADD END p3q4 ===*/
+
 }

--- a/src/userprog/process.c
+++ b/src/userprog/process.c
@@ -20,10 +20,12 @@
 /* === ADD START jinho p2q2 ===*/
 #include "userprog/syscall.h"
 /* === ADD END jinho p2q2 ===*/
-
 /* === ADD START p3q1 ===*/
 #include "vm/page.h"
-/* === ADD END p3q1 ===*/
+/* === ADD END p3q3 ===*/
+/* === ADD START p3q1 ===*/
+#include "vm/mmap.h"
+/* === ADD END p3q3 ===*/
 
 
 static thread_func start_process NO_RETURN;
@@ -176,6 +178,10 @@ start_process (void *cmdline_)
   pmap_init ( &(cur->pmap) );
   /* === ADD END p3q1 ===*/
 
+  /* === ADD START p3q3 ===*/
+  list_init( &(cur->mmap_list) );
+  /* === ADD END p3q3 ===*/
+
   /* Initialize interrupt frame and load executable. */
   memset (&if_, 0, sizeof if_);
   if_.gs = if_.fs = if_.es = if_.ds = if_.ss = SEL_UDSEG;
@@ -307,6 +313,7 @@ process_exit (void)
   // NOTE : allow modification of current file
   file_close(cur->current_file);
   /* === ADD END jihun p2q3 ===*/
+
 }
 
 /* Sets up the CPU for running user code in the current

--- a/src/userprog/process.c
+++ b/src/userprog/process.c
@@ -173,7 +173,7 @@ start_process (void *cmdline_)
   /* === ADD START p3q1 ===*/
   // NOTE : hash table must be set before load () is called
   struct thread* cur = thread_current();
-  pmap_init ( cur->pmap );
+  pmap_init ( &(cur->pmap) );
   /* === ADD END p3q1 ===*/
 
   /* Initialize interrupt frame and load executable. */
@@ -196,7 +196,6 @@ start_process (void *cmdline_)
 
 /* === ADD START jinho p2q2 ===*/
   /* If load failed, quit. */
-  struct thread* cur = thread_current();
   palloc_free_page (cmdline);
   palloc_free_page (cmdline_copy);
   if (!success){
@@ -534,7 +533,9 @@ load (const char *file_name, void (**eip) (void), void **esp)
 
 /* load() helpers. */
 
-static bool install_page (void *upage, void *kpage, bool writable);
+/* === DEL START p3q2 ===*/
+//static bool install_page (void *upage, void *kpage, bool writable);
+/* === DEL END p3q2 ===*/
 
 /* Checks whether PHDR describes a valid, loadable segment in
    FILE and returns true if so, false otherwise. */
@@ -701,7 +702,11 @@ setup_stack (void **esp)
    with palloc_get_page().
    Returns true on success, false if UPAGE is already mapped or
    if memory allocation fails. */
-static bool
+/* === DEL START p3q2 ===*/
+//static bool
+/* === DEL END p3q2 ===*/
+//* === ADD START p3q2 ===*/
+bool
 install_page (void *upage, void *kpage, bool writable)
 {
   struct thread *t = thread_current ();

--- a/src/userprog/process.c
+++ b/src/userprog/process.c
@@ -679,7 +679,9 @@ setup_stack (void **esp)
   /* === ADD START p3q1 ===*/
   if( success ) {
     struct pme* pme_to_alloc = create_pme();
-    pme_to_alloc->vaddr = ((uint8_t *) PHYS_BASE) - PGSIZE;
+    void* stack_addr = ((uint8_t *) PHYS_BASE) - PGSIZE;
+    ASSERT( pg_ofs(stack_addr) == 0 );
+    pme_to_alloc->vaddr = stack_addr;
     pme_to_alloc->load_status = true;
     pme_to_alloc->write_permission = true;
     pme_to_alloc->type = PME_NULL;

--- a/src/userprog/process.h
+++ b/src/userprog/process.h
@@ -8,4 +8,9 @@ int process_wait (tid_t);
 void process_exit (void);
 void process_activate (void);
 
+/* === ADD START p3q2 ===*/
+bool install_page (void *, void *, bool);
+/* === ADD END p3q2 ===*/
+
+
 #endif /* userprog/process.h */

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -361,7 +361,7 @@ mapid_t mmap(int fd, void* addr) {
   struct file* f_copy = file_reopen(f);
   ASSERT( f_copy != NULL);
 
-  // generate and insert mmap_meta to struct
+  // file_reopen
   mapid_t mid = 0;
 
   struct mmap_meta* mmeta = malloc( sizeof(struct mmap_meta) );
@@ -391,10 +391,10 @@ void munmap(mapid_t mapping) {
   ASSERT(mmeta != NULL);
 
   // clear all pmes
+  lock_acquire(&fs_lock);
   ASSERT( unload_mmap( mmeta ) == true );
 
   // close file
-  lock_acquire(&fs_lock);
   file_close( mmeta->file );
   lock_release(&fs_lock);
 

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -345,9 +345,9 @@ static bool isValidUserPointer(const void *ptr, bool writable) {
   /* === DEL START p3q1 ===*/
 //  if( pagedir_get_page(cur->pagedir, ptr) == NULL ) { return false; }
   /* === DEL END p3q1 ===*/
-  struct pme* pmap_get_pme ( &(cur->pmap), ptr );
-  if ( pme == NULL ) { return false; }
-  if ( writable && (pme->write_permission == false) ) { return false; }
+  struct pme* pme_get = pmap_get_pme ( &(cur->pmap), ptr );
+  if ( pme_get == NULL ) { return false; }
+  if ( writable && (pme_get->write_permission == false) ) { return false; }
 
   // All cases passed.
   return true;

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -41,8 +41,6 @@ int write(int, const void *, unsigned);
 void seek(int, unsigned);
 unsigned tell(int);
 void close(int);
-mapid_t mmap(int, void *);
-void munmap(mapid_t);
 
 // NOTE : helper functions (locally used)
 static bool isValidUserPointer(const void *, bool);
@@ -156,18 +154,6 @@ syscall_handler (struct intr_frame *f)
       handleInvalidUserPointer(args[1], 4);
       close(*(args[1]));
       break;
-    /* === ADD START p3q3 ===*/
-    case SYS_MMAP:
-      handleInvalidUserPointer(args[1], 4);
-      handleInvalidUserPointer(args[2], 4);
-      handleInvalidUserPointer(*(args[2]), sizeof(char) );
-      f->eax = mmap( *(args[1]), *(args[2]) );
-      break;
-    case SYS_MUNMAP:
-      handleInvalidUserPointer(args[1], 4);
-      munmap( *(args[1]) );
-      break;
-    /* === ADD END p3q3 ===*/
     default:
       // NOTE : invalid system call
       exit(-1);
@@ -339,17 +325,8 @@ void close(int fd){
   lock_release(&fs_lock);
   return;
 }
+
 /* === ADD END jinho p2q2 ===*/
-/* === ADD START p3q3 ===*/
-mapid_t mmap(int fd, void* addr) {
-
-}
-void munmap(mapid_t mapping) {
-
-}
-/* === ADD END p3q3 ===*/
-
-
 
 /* === ADD START jinho p2q2 ===*/
 

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -353,36 +353,27 @@ mapid_t mmap(int fd, void* addr) {
   if( f == NULL ) { return -1; }
   if( check_mmap_availability( fd, addr ) == false) { return -1; }
 
-  //printf("mmap not fauil1\n");
-
   // from now on, file is assumed to be open, consider the lock
   lock_acquire(&fs_lock);
   bool success = true;
 
-  //printf("mmap not fauil2\n");
-
   // file_reopen
   struct file* f_copy = file_reopen(f);
   ASSERT( f_copy != NULL);
-  //printf("mmap not fauil2-1\n");
 
   // generate and insert mmap_meta to struct
   mapid_t mid = 0;
-  //printf("mmap not fauil2-2-2\n");
 
   struct mmap_meta* mmeta = malloc( sizeof(struct mmap_meta) );
   mmap_meta_init(mmeta);
   mmeta->mapid = mid;
   mmeta->file = f_copy;
 
-  //printf("mmap not fauil33\n");
-
   // load_mmap (lazy loading)
   success = load_mmap( f_copy, mmeta, addr );
   ASSERT( success ); // if this assertion fails,
                      // manually deallocate pmes
   list_push_back( &(thread_current()->mmap_list), &(mmeta->elem) );
-  //printf("mmap not fauil3\n");
 
   lock_release(&fs_lock);
   // return mapid

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -41,6 +41,8 @@ int write(int, const void *, unsigned);
 void seek(int, unsigned);
 unsigned tell(int);
 void close(int);
+mapid_t mmap(int, void *);
+void munmap(mapid_t);
 
 // NOTE : helper functions (locally used)
 static bool isValidUserPointer(const void *, bool);
@@ -154,6 +156,18 @@ syscall_handler (struct intr_frame *f)
       handleInvalidUserPointer(args[1], 4);
       close(*(args[1]));
       break;
+    /* === ADD START p3q3 ===*/
+    case SYS_MMAP:
+      handleInvalidUserPointer(args[1], 4);
+      handleInvalidUserPointer(args[2], 4);
+      handleInvalidUserPointer(*(args[2]), sizeof(char) );
+      f->eax = mmap( *(args[1]), *(args[2]) );
+      break;
+    case SYS_MUNMAP:
+      handleInvalidUserPointer(args[1], 4);
+      munmap( *(args[1]) );
+      break;
+    /* === ADD END p3q3 ===*/
     default:
       // NOTE : invalid system call
       exit(-1);
@@ -325,8 +339,17 @@ void close(int fd){
   lock_release(&fs_lock);
   return;
 }
-
 /* === ADD END jinho p2q2 ===*/
+/* === ADD START p3q3 ===*/
+mapid_t mmap(int fd, void* addr) {
+
+}
+void munmap(mapid_t mapping) {
+
+}
+/* === ADD END p3q3 ===*/
+
+
 
 /* === ADD START jinho p2q2 ===*/
 

--- a/src/vm/frame.c
+++ b/src/vm/frame.c
@@ -107,6 +107,7 @@ bool evict_page( struct frame* f ) {
       pme->pme_swap_index = swap_out( kaddr );
       break;
     }
+    default: { ASSERT(0); }
   }
 
   pme->load_status = false;

--- a/src/vm/frame.c
+++ b/src/vm/frame.c
@@ -1,14 +1,204 @@
 /* === ADD START p3q4 ===*/
 
 #include "frame.h"
+#include "vaddr.h"
+#include <list.h>
+#include "vm/page.h"
+#include "threads/synch.h"
+#include "userprog/pagedir.h"
+#include "vm/swap.h"
+
 
 // NOTE : the frame table is globally declared.
 //        i.e. all processes shares a single frame table.
 static struct list frame_table;
+static struct frame* victim;
+static struct lock victim_lock;
 
-struct frame* victim;
-struct lock victim_lock;
+void frame_table_init() {
+  list_init ( &frame_table );
+  victim = NULL;
+  lock_init( &victim_lock );
+  return;
+}
 
-// todo all
+// NOTE : here, vaddr is not inserted.
+struct frame* create_frame ( void* kaddr, struct thread* thr ) {
+  struct frame* frame = malloc ( sizeof( struct frame ) );
+  frame->kaddr = kaddr;
+  frame->vaddr = NULL;
+  frame->vaddr_installed = false;
+  frame->thr = thr;
+
+  return frame;
+}
+
+void install_vaddr_to_frame ( struct frame* f, void* vaddr ) {
+  f->vaddr = vaddr;
+  f->vaddr_installed = true;
+}
+
+struct frame* find_frame( void* kaddr ) {
+
+  lock_acquire( &victim_lock );
+
+  ASSERT (pg_ofs (kaddr) == 0);
+
+  struct list_elem *e;
+  for ( e = list_begin (&frame_table);
+        e != list_end (&frame_table);
+        e = list_next (e)       )
+    {
+        struct frame *f = list_entry(e, struct frame, elem);
+        if( f->kaddr == kaddr ) { // found
+          return f;
+        }
+    }
+  lock_release( &victim_lock );
+  return NULL; // not found
+}
+
+void insert_frame( struct frame* f ){
+  lock_acquire( &victim_lock );
+  list_push_back( &frame_table, &(f->elem) );
+  lock_release( &victim_lock );
+
+}
+
+void remove_frame( struct frame* f ) {
+  lock_acquire( &victim_lock );
+  list_remove( &(f->elem) );
+  free( f );
+  lock_release( &victim_lock );
+}
+
+/* Page Replacement Related */
+
+// NOTE: 1. proceed (swap/flush)
+//       2. update pme (not loaded)
+//       3. uninstall from pagedir
+bool evict_page( struct frame* f ) {
+
+  bool success = true;
+  ASSERT( f != NULL );
+  ASSERT( f->vaddr_installed == true );
+
+  // get pme of that frame
+  struct pme* pme = pmap_get_pme( &(f->thr->pmap), f->vaddr );
+  ASSERT( pme->load_status == true );
+
+  switch( pme->type ) {
+    case MMAP: {
+      void* kaddr = pagedir_get_page( f->thr->pagedir, e->vaddr );
+      pmap_flush_pme_data( pme, kaddr );
+      break;
+    }
+    case PME_NULL :
+    case PME_EXEC :  {
+      void* kaddr = pagedir_get_page( f->thr->pagedir, e->vaddr );
+      pme->type = PME_SWAP;
+      pme->pme_swap_index = swap_out( kaddr );
+      break;
+    }
+    case PME_SWAP : {
+      void* kaddr = pagedir_get_page( f->thr->pagedir, e->vaddr );
+      pme->pme_swap_index = swap_out( kaddr );
+      break;
+    }
+  }
+
+  pme->load_status = false;
+  pagedir_clear_page( f->thr->pagedir, pme->vaddr );
+
+  return success;
+}
+
+// NOTE : this function must be stateless.
+//        the result of this function ONLY
+//        depends on VICTIM.
+struct frame* get_current_victim() {
+  lock_acquire( &victim_lock );
+  if( victim == NULL ) {
+    set_next_victim();
+  }
+  struct frame* f = victim;
+  lock_release( &victim_lock );
+
+  // NOTE : if victim cannot be selected,
+  //        that would be a very serious problem
+  //        reasonable to panic
+  ASSERT( f != NULL );
+  return f;
+}
+
+// NOTE : here, we implement 2nd chance algorithm
+//        if victim is null, set victim starting from the front
+//        we do not set as victim if vaddr is not installed.
+void set_next_victim() {
+
+  lock_acquire( &victim_lock );
+  ASSERT( list_size(&frame_table) > 0 )
+
+  // NOTE : we maintain a circular search
+  struct list_elem *e;
+  struct frame* ptr;
+  if( victim == NULL ) {
+    e = list_begin(&frame_table); // e starts from begin
+  } else {
+    e = victim->elem;             // e starts from current victim
+  }
+  for ( ;
+        e != list_end (&frame_table);
+        e = _circular_next (e) )
+  {
+    ptr = list_entry(e, struct frame, elem);
+    if( ptr->vaddr_installed ) {
+      if( pagedir_is_accessed( &(ptr->thr->pagedir), ptr->vaddr )) {
+        // if accessed == 1, give second chance
+        pagedir_set_accessed( &(ptr->thr->pagedir), ptr->vaddr, false );
+      } else{
+        // if accessed == 0, select
+        victim = ptr;
+        break;
+      }
+    }
+  }
+  lock_release( &victim_lock );
+}
+
+// NOTE : an internal function for circular search
+static list_elem* _circular_next( list_elem* e ){
+  if ( e == list_rbegin (&frame_table) ) {
+    return list_begin( &frame_table );
+  } else {
+    return list_next(e);
+  }
+}
+
+bool is_victim ( struct frame* f ){
+  if( victim == NULL ) { return false; }
+  if( victim == f) { return true; }
+  return false;
+}
+
+void replace_victim ( struct frame* f ) {
+
+  struct frame* f_new;
+  int set_cnt = 0;
+
+  do {
+    f_new = get_current_victim();
+    // something serious has happened!
+    set_next_victim();
+    set_cnt +=1;
+    if( set_cnt >= 10 ){ ASSERT( 0 ) ; } // toerase
+  } while ( f_new == f );
+
+  // NOTE : the replaced victim should never be
+  //        same with the original one.
+  ASSERT( f_new != f ) ;
+
+  victim = f_new;
+}
 
 /* === ADD END p3q4 ===*/

--- a/src/vm/frame.c
+++ b/src/vm/frame.c
@@ -2,7 +2,13 @@
 
 #include "frame.h"
 
-// Frame Table
-static struct list ftable;
+// NOTE : the frame table is globally declared.
+//        i.e. all processes shares a single frame table.
+static struct list frame_table;
+
+struct frame* victim;
+struct lock victim_lock;
+
+// todo all
 
 /* === ADD END p3q4 ===*/

--- a/src/vm/frame.c
+++ b/src/vm/frame.c
@@ -1,0 +1,8 @@
+/* === ADD START p3q4 ===*/
+
+#include "frame.h"
+
+// Frame Table
+static struct list ftable;
+
+/* === ADD END p3q4 ===*/

--- a/src/vm/frame.h
+++ b/src/vm/frame.h
@@ -2,21 +2,31 @@
 #ifndef VM_FRAME_H
 #define VM_FRAME_H
 
-#include "list.h"
+#include <list.h>
+#include "threads/thread.h"
 
 // NOTE : The overall design motivation of frame
 //        is to resemble the interfaces of palloc
 //        as much as possible.
-
+//
 struct frame {
-  // TODO
+    void*              kaddr;  // kernel memory address
+    struct thread*     thr;    // thread pointer
+    struct list_elem   elem;
 };
 
-void vm_frame_init ();
-void vm_allocate_frame ();
-void vm_free_frame ();
+// todo all
 
-// todo eviction related
+
+void frame_table_init();
+void insert_frame();
+void remove_frame();
+
+/* page replacement related */
+bool evict_page();
+
+void get_current_victim();
+void set_next_victim();
 
 
 #endif //VM_FRAME_H

--- a/src/vm/frame.h
+++ b/src/vm/frame.h
@@ -1,0 +1,24 @@
+/* === ADD START p3q4 ===*/
+#ifndef VM_FRAME_H
+#define VM_FRAME_H
+
+#include "list.h"
+
+// NOTE : The overall design motivation of frame
+//        is to resemble the interfaces of palloc
+//        as much as possible.
+
+struct frame {
+  // TODO
+};
+
+void vm_frame_init ();
+void vm_allocate_frame ();
+void vm_free_frame ();
+
+// todo eviction related
+
+
+#endif //VM_FRAME_H
+
+/* === ADD END p3q4 ===*/

--- a/src/vm/frame.h
+++ b/src/vm/frame.h
@@ -4,30 +4,35 @@
 
 #include <list.h>
 #include "threads/thread.h"
+#include "vm/page.h"
 
 // NOTE : The overall design motivation of frame
 //        is to resemble the interfaces of palloc
 //        as much as possible.
 //
 struct frame {
-    void*              kaddr;  // kernel memory address
-    struct thread*     thr;    // thread pointer
+    void*              kaddr;           // kernel memory address
+    bool               vaddr_installed; // whether vaddr is installed
+    void*              vaddr;           // virtual memory address of that page
+    struct thread*     thr;             // thread pointer
     struct list_elem   elem;
 };
 
-// todo all
-
-
 void frame_table_init();
-void insert_frame();
-void remove_frame();
+
+struct frame* create_frame ( void* , struct thread* );
+bool install_vaddr_to_frame ( void* );
+void find_frame( void* );
+void insert_frame( struct frame* );
+void remove_frame( struct frame* );
 
 /* page replacement related */
-bool evict_page();
+bool evict_page( struct frame* );
 
-void get_current_victim();
+struct frame* get_current_victim();
 void set_next_victim();
-
+bool is_victim ( struct frame* );
+void replace_victim( struct frame* );
 
 #endif //VM_FRAME_H
 

--- a/src/vm/frame.h
+++ b/src/vm/frame.h
@@ -21,8 +21,8 @@ struct frame {
 void frame_table_init();
 
 struct frame* create_frame ( void* , struct thread* );
-bool install_vaddr_to_frame ( void* );
-void find_frame( void* );
+void install_vaddr_to_frame ( struct frame*, void* );
+struct frame* find_frame( void* );
 void insert_frame( struct frame* );
 void remove_frame( struct frame* );
 

--- a/src/vm/mmap.c
+++ b/src/vm/mmap.c
@@ -180,23 +180,4 @@ bool unload_mmap( struct mmap_meta* mmeta ) {
   return success;
 }
 
-bool flush_mmap( struct mmap_meta* mmeta ) {
-
-  // clear pme
-  // NOTE : In each pmap_clear_pme, we will free pme.
-  //        Thus we need to retrieve crucial values before
-  //        making changes to the list every iteration.
-  struct list_elem *e, *e1;
-  struct list_elem *eb = list_begin( &mmeta->pme_list );
-  struct list_elem *ee = list_end( &mmeta->pme_list );
-
-  for (e = eb; e != ee; e = e1) {
-    struct pme* pme = list_entry (e, struct pme, mmap_elem);
-    e1 = list_next (e);
-    // if one of the clear action fails, the unload is marked failure
-    success = success && pmap_clear_pme( &(cur->pmap), pme, true );
-  }
-
-}
-
 /* === ADD END p3q3 ===*/

--- a/src/vm/mmap.c
+++ b/src/vm/mmap.c
@@ -11,7 +11,6 @@
 
 void mmap_meta_init(struct mmap_meta* mmeta) {
   list_init( &(mmeta->pme_list) );
-  lock_init( &mmap_lock );
   return;
 }
 
@@ -75,11 +74,11 @@ bool load_mmap( struct file* file, struct mmap_meta* mmeta, void* upage ) {
   size_t read_bytes = file_length(file);
   size_t zero_bytes = (ROUND_UP(read_bytes , PGSIZE) - read_bytes);
 
+  size_t ofs = 0;
   while (read_bytes > 0 || zero_bytes > 0)
   {
     size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
     size_t page_zero_bytes = PGSIZE - page_read_bytes;
-    size_t ofs = 0;
 
     struct pme* pme_to_alloc = create_pme();
     pme_to_alloc->vaddr = upage;

--- a/src/vm/mmap.c
+++ b/src/vm/mmap.c
@@ -11,6 +11,7 @@
 
 void mmap_meta_init(struct mmap_meta* mmeta) {
   list_init( &(mmeta->pme_list) );
+  lock_init( &mmap_lock );
   return;
 }
 
@@ -174,7 +175,7 @@ bool unload_mmap( struct mmap_meta* mmeta ) {
     struct pme* pme = list_entry (e, struct pme, mmap_elem);
     e1 = list_next (e);
     // if one of the clear action fails, the unload is marked failure
-    success = success && pmap_clear_pme( &(cur->pmap), pme, true );
+    success = success && pmap_clear_pme( &(cur->pmap), pme );
   }
 
   return success;

--- a/src/vm/mmap.c
+++ b/src/vm/mmap.c
@@ -50,12 +50,10 @@ mapid_t gen_mmap_id () {
   struct thread* cur = thread_current();
   mapid_t maxid = 0;
   mapid_t newid;
-  //printf("mmap not fauil123 \n" );
 
   if( list_empty(&cur->mmap_list) ) {    // when mmap_list empty, mapid=0
     return 0;
   }
-  //printf("mmap not fauil12333 \n" );
 
   struct list_elem *e;
   for (e = list_begin( &cur->mmap_list );
@@ -65,7 +63,6 @@ mapid_t gen_mmap_id () {
     struct mmap_meta *mmeta = list_entry (e, struct mmap_meta, elem);
     maxid = mmeta->mapid > (int) maxid ? mmeta->mapid : maxid;
   }
-  //printf("mmap not 789\n");
 
   newid = maxid + 1;
   return newid;

--- a/src/vm/mmap.c
+++ b/src/vm/mmap.c
@@ -1,0 +1,188 @@
+/* === ADD START p3q1 ===*/
+
+#include <list.h>
+#include "mmap.h"
+#include "threads/thread.h"
+#include "threads/palloc.h"
+#include "userprog/syscall.h"
+#include "filesys/file.h"
+#include "threads/vaddr.h"
+#include <round.h>
+
+void mmap_meta_init(struct mmap_meta* mmeta) {
+  list_init( &(mmeta->pme_list) );
+  return;
+}
+
+bool check_mmap_availability(int fd, void* addr) {
+
+  struct thread* cur = thread_current();
+
+  // check basic conditions
+  if( addr == NULL ) { return false;}
+  if(  fd == 0
+    || fd == 1
+    || pg_ofs(addr)!= 0
+    || addr == (void*) 0
+    ) { return false; }
+
+  // check if file length != 0
+  int fsize = filesize( fd ); // (syscall!)
+  if( fsize == 0 ){ return false; }
+
+  void* pageaddr_st = pg_round_down(addr);
+  void* pageaddr_en = pg_round_down(addr+fsize);
+  // check if ranges of pages map overlaps of any existing pmes
+  void* ad;
+  bool page_exists = false;
+  for( ad = pageaddr_st ; ad <=pageaddr_en ; ad += PGSIZE) {
+    if ( pmap_get_pme( &(cur->pmap), ad) != NULL ) {
+      page_exists = true;
+    }
+  }
+  if( page_exists ) { return false; }
+
+  return true;
+}
+
+mapid_t gen_mmap_id () {
+
+  struct thread* cur = thread_current();
+  mapid_t maxid = 0;
+  mapid_t newid;
+  //printf("mmap not fauil123 \n" );
+
+  if( list_empty(&cur->mmap_list) ) {    // when mmap_list empty, mapid=0
+    return 0;
+  }
+  //printf("mmap not fauil12333 \n" );
+
+  struct list_elem *e;
+  for (e = list_begin( &cur->mmap_list );
+       e != list_end( &cur->mmap_list );
+       e = list_next (e)) {
+
+    struct mmap_meta *mmeta = list_entry (e, struct mmap_meta, elem);
+    maxid = mmeta->mapid > (int) maxid ? mmeta->mapid : maxid;
+  }
+  //printf("mmap not 789\n");
+
+  newid = maxid + 1;
+  return newid;
+}
+
+// NOTE : this has similar contents with load_segment()
+bool load_mmap( struct file* file, struct mmap_meta* mmeta, void* upage ) {
+
+  size_t read_bytes = file_length(file);
+  size_t zero_bytes = (ROUND_UP(read_bytes , PGSIZE) - read_bytes);
+
+  while (read_bytes > 0 || zero_bytes > 0)
+  {
+    size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
+    size_t page_zero_bytes = PGSIZE - page_read_bytes;
+    size_t ofs = 0;
+
+    struct pme* pme_to_alloc = create_pme();
+    pme_to_alloc->vaddr = upage;
+    pme_to_alloc->load_status = false;
+    pme_to_alloc->write_permission = true;
+    pme_to_alloc->type = PME_MMAP;
+    pme_to_alloc->pme_mmap_file = mmeta->file;
+    pme_to_alloc->pme_mmap_read_offset = ofs;
+    pme_to_alloc->pme_mmap_read_bytes = page_read_bytes;
+    pme_to_alloc->pme_mmap_zero_bytes = page_zero_bytes;
+
+    if( pmap_set_pme( &(thread_current()->pmap), pme_to_alloc ) == false ){
+      return false;
+    }
+    read_bytes -= page_read_bytes;
+    zero_bytes -= page_zero_bytes;
+    upage += PGSIZE;
+    ofs += page_read_bytes;
+
+    // insert pme to pme_list
+    list_push_back( &(mmeta->pme_list), &(pme_to_alloc->mmap_elem) );
+  }
+  return true;
+}
+
+// NOTE : this has similar contents with load_segment_on_demand()
+bool load_mmap_on_demand( struct mmap_meta* mmeta, struct pme* e, void* kpage ) {
+
+  bool success = true;
+  struct file* f = mmeta->file;
+
+  // Load file starting from offset
+  if (file_read_at( f,
+                    kpage,
+                    e->pme_mmap_read_bytes,
+                    e->pme_mmap_read_offset )
+      != (int) e->pme_mmap_read_bytes)
+  {
+    return false;
+  }
+  // Set remaining page area to zero
+  memset( kpage + e->pme_mmap_read_bytes, 0, e->pme_mmap_zero_bytes);
+
+  return success;
+}
+
+struct mmap_meta* get_mmap_meta (mapid_t mapping) {
+  struct thread* cur = thread_current();
+  struct list_elem *e;
+
+  if( list_empty(&cur->mmap_list) == true ) { return NULL; }
+  for (e = list_begin( &cur->mmap_list );
+       e != list_end( &cur->mmap_list );
+       e = list_next (e)) {
+
+    struct mmap_meta *mmeta = list_entry (e, struct mmap_meta, elem);
+    // condition
+    if( mmeta->mapid == mapping ) { return mmeta; }
+  }
+  return NULL;
+}
+
+struct mmap_meta* get_mmap_meta_from_file (struct file* f) {
+  struct thread* cur = thread_current();
+  struct list_elem *e;
+
+  if( list_empty(&cur->mmap_list) == true ) { return NULL; }
+  for (e = list_begin( &cur->mmap_list );
+       e != list_end( &cur->mmap_list );
+       e = list_next (e)) {
+
+    struct mmap_meta *mmeta = list_entry (e, struct mmap_meta, elem);
+    // condition
+    if( mmeta->file == f ) { return mmeta; }
+  }
+  return NULL;
+}
+
+bool unload_mmap( struct mmap_meta* mmeta ) {
+
+  bool success = true;
+  struct thread* cur = thread_current();
+
+  int cnt = 0;
+
+  // clear pme
+  // NOTE : In each pmap_clear_pme, we will free pme.
+  //        Thus we need to retrieve crucial values before
+  //        making changes to the list every iteration.
+  struct list_elem *e, *e1;
+  struct list_elem *eb = list_begin( &mmeta->pme_list );
+  struct list_elem *ee = list_end( &mmeta->pme_list );
+
+  for (e = eb; e != ee; e = e1) {
+    struct pme* pme = list_entry (e, struct pme, mmap_elem);
+    e1 = list_next (e);
+    // if one of the clear action fails, the unload is marked failure
+    success = success && pmap_clear_pme( &(cur->pmap), pme, true );
+  }
+
+  return success;
+}
+
+/* === ADD END p3q3 ===*/

--- a/src/vm/mmap.c
+++ b/src/vm/mmap.c
@@ -162,8 +162,6 @@ bool unload_mmap( struct mmap_meta* mmeta ) {
   bool success = true;
   struct thread* cur = thread_current();
 
-  int cnt = 0;
-
   // clear pme
   // NOTE : In each pmap_clear_pme, we will free pme.
   //        Thus we need to retrieve crucial values before
@@ -180,6 +178,25 @@ bool unload_mmap( struct mmap_meta* mmeta ) {
   }
 
   return success;
+}
+
+bool flush_mmap( struct mmap_meta* mmeta ) {
+
+  // clear pme
+  // NOTE : In each pmap_clear_pme, we will free pme.
+  //        Thus we need to retrieve crucial values before
+  //        making changes to the list every iteration.
+  struct list_elem *e, *e1;
+  struct list_elem *eb = list_begin( &mmeta->pme_list );
+  struct list_elem *ee = list_end( &mmeta->pme_list );
+
+  for (e = eb; e != ee; e = e1) {
+    struct pme* pme = list_entry (e, struct pme, mmap_elem);
+    e1 = list_next (e);
+    // if one of the clear action fails, the unload is marked failure
+    success = success && pmap_clear_pme( &(cur->pmap), pme, true );
+  }
+
 }
 
 /* === ADD END p3q3 ===*/

--- a/src/vm/mmap.h
+++ b/src/vm/mmap.h
@@ -1,0 +1,32 @@
+/* === ADD START p3q3 ===*/
+
+#ifndef VM_MMAP_H
+#define VM_MMAP_H
+
+#include <list.h>
+#include "filesys/file.h"
+#include "vm/page.h"
+
+typedef int mapid_t;
+
+struct mmap_meta {
+    mapid_t mapid;
+    struct file* file;
+    struct list pme_list;
+    struct list_elem elem;
+};
+
+void mmap_meta_init(struct mmap_meta* );
+bool check_mmap_availability(int, void*);
+mapid_t gen_mmap_id ();
+
+bool load_mmap( struct file*, struct mmap_meta*, void*);
+bool load_mmap_on_demand(struct mmap_meta*, struct pme*, void*) ;
+
+struct mmap_meta* get_mmap_meta (mapid_t);
+struct mmap_meta* get_mmap_meta_from_file (struct file*);
+bool unload_mmap( struct mmap_meta* );
+
+#endif //VM_MMAP_H
+
+/* === ADD END p3q3 ===*/

--- a/src/vm/mmap.h
+++ b/src/vm/mmap.h
@@ -6,6 +6,7 @@
 #include <list.h>
 #include "filesys/file.h"
 #include "vm/page.h"
+#include "threads/synch.h"
 
 typedef int mapid_t;
 
@@ -26,6 +27,8 @@ bool load_mmap_on_demand(struct mmap_meta*, struct pme*, void*) ;
 struct mmap_meta* get_mmap_meta (mapid_t);
 struct mmap_meta* get_mmap_meta_from_file (struct file*);
 bool unload_mmap( struct mmap_meta* );
+
+struct lock mmap_lock;
 
 #endif //VM_MMAP_H
 

--- a/src/vm/mmap.h
+++ b/src/vm/mmap.h
@@ -28,8 +28,6 @@ struct mmap_meta* get_mmap_meta (mapid_t);
 struct mmap_meta* get_mmap_meta_from_file (struct file*);
 bool unload_mmap( struct mmap_meta* );
 
-struct lock mmap_lock;
-
 #endif //VM_MMAP_H
 
 /* === ADD END p3q3 ===*/

--- a/src/vm/page.c
+++ b/src/vm/page.c
@@ -1,0 +1,132 @@
+/* === ADD START p3q1 ===*/
+
+#include "vm/page.h"
+
+#include "lib/kernel/hash.h"
+#include "threads/vaddr.h"
+#include "threads/thread.h"
+#include "threads/malloc.h"
+#include "threads/pte.h"
+#include "userprog/pagedir.h"
+#include "userprog/syscall.h"
+#include "filesys/file.h"
+#include "string.h"
+
+
+struct pme* create_pme (){
+  // NOTE : pme_new can be NULL due to memory lackage
+  struct pme* pme_new = malloc( sizeof(struct pme) );
+  ASSERT( pme_new != NULL ); // (actually this should never happen)
+  return pme_new;
+}
+
+void pmap_init (struct hash* pmap){
+  hash_init(pmap, pmap_hash_function, &pme_less, NULL);
+}
+
+static unsigned pmap_hash_function (const struct hash_elem* e, void* UNUSED){
+  const struct pme* query_pme;
+  query_pme = hash_entry (e, struct pme, elem);
+
+  return hash_int ( &query_pme->vaddr );
+}
+
+static bool pme_less (const struct hash_elem* e1, const struct hash_elem* e2, void* UNUSED){
+  const struct pme *e1_pme = hash_entry (e1, struct pme, elem);
+  const struct pme *e2_pme = hash_entry (e2, struct pme, elem);
+
+  return e1_pme->vaddr < e2_pme->vaddr;
+}
+
+
+// NOTE : query pme that is in charge of vaddr
+struct pme* pmap_get_pme (struct hash* pmap, void* vaddr) {
+  return lookup_pme( pmap, vaddr );
+}
+
+// NOTE : insert pme to pmap
+bool pmap_set_pme (struct hash* pmap, struct pme* e) {
+  struct pme_lookup = lookup_pme( pmap, e->vaddr );
+  // the entry should not already exist before setting
+  if( pme_lookup != NULL ){ return false; }
+
+  // hash insert
+  hash_insert( pmap, &(e->elem) );
+  return true;
+}
+
+// NOTE : delete pme from pmap (pme still remains in the memory)
+bool pmap_clear_pme (struct hash* pmap, struct pme* e){
+  struct pme_lookup = lookup_pme( pmap, e->vaddr );
+  // the entry should exist before setting
+  if( pme_lookup == NULL ){ return false; }
+
+  void* kaddr = pagedir_get_page( cur->pagedir, e->vaddr );
+  palloc_free_page( kaddr );
+  pagedir_clear_page( cur->pagedir, e->vaddr );
+  free( e );
+
+  // hash delete
+  hash_delete( pmap, &(e->elem) );
+
+  return true;
+}
+
+// NOTE : used internally
+static struct pme* lookup_pme (struct hash* pmap, void* vaddr){
+  struct pme temp_pme;
+  struct hash_elem target_elem;
+
+  // NOTE : given a vaddr, we query for page address
+  temp_pme.vaddr = pg_round_down( vaddr );
+  target_elem = hash_find (pmap, &temp_pme.elem);
+
+  if (target_elem == NULL) { return NULL; }         // hash entry not found
+  return hash_entry (target_elem, struct pme, elem) // hash entry found
+}
+
+// NOTE : destroys all elements and the hash table itself
+void pmap_destroy (struct hash* pmap){
+  // hash_destroy
+  hash_destroy( pmap, pmap_destroy_function );
+}
+
+// NOTE : deallocates page if loaded, and frees pme
+static void pmap_destroy_function (struct hash_elem *e, void *aux UNUSED){
+  struct pme* pme_target = hash_entry(e, struct pme, elem);
+  ASSERT( pme_target != NULL );
+
+  struct thread* cur = thread_current();
+  void* kaddr;
+
+  // if loaded, free page
+  if( pme_target->load_status == true ) {
+    kaddr = pagedir_get_page( cur->pagedir, pme_target->vaddr );
+    palloc_free_page( kaddr );
+    pagedir_clear_page( cur->pagedir, pme_target->vaddr );
+  }
+
+  // dealloc pme
+  free( pme_target );
+}
+
+bool load_segment_on_demand ( struct pme* e, void* kpage ) {
+
+  bool success = true;
+  // Load file starting from offset
+  if (file_read_at( e->pme_exec_file,
+                    kpage,
+                    e->pme_exec_read_bytes,
+                    e->pme_exec_read_offset )
+        != (int) e->page_read_bytes)
+    {
+      return false;
+    }
+
+  // Set remaining page area to zero
+  memset( kpage + e->pme_exec_read_bytes, 0, e->page_zero_bytes);
+
+  return success;
+}
+
+/* === ADD END p3q1 ===*/

--- a/src/vm/page.c
+++ b/src/vm/page.c
@@ -21,7 +21,7 @@ struct pme* create_pme (){
 }
 
 void pmap_init (struct hash* pmap){
-  hash_init(pmap, pmap_hash_function, &pme_less, NULL);
+  hash_init(pmap, pmap_hash_function, &pme_less_function, NULL);
 }
 
 static unsigned pmap_hash_function (const struct hash_elem* e, void* UNUSED){
@@ -31,7 +31,7 @@ static unsigned pmap_hash_function (const struct hash_elem* e, void* UNUSED){
   return hash_int ( &query_pme->vaddr );
 }
 
-static bool pme_less (const struct hash_elem* e1, const struct hash_elem* e2, void* UNUSED){
+static bool pme_less_function (const struct hash_elem* e1, const struct hash_elem* e2, void* UNUSED){
   const struct pme *e1_pme = hash_entry (e1, struct pme, elem);
   const struct pme *e2_pme = hash_entry (e2, struct pme, elem);
 
@@ -55,7 +55,7 @@ bool pmap_set_pme (struct hash* pmap, struct pme* e) {
   return true;
 }
 
-// NOTE : delete pme from pmap (pme still remains in the memory)
+// NOTE : delete pme from pmap (pme itself still remains in the memory)
 bool pmap_clear_pme (struct hash* pmap, struct pme* e){
   struct pme_lookup = lookup_pme( pmap, e->vaddr );
   // the entry should exist before setting

--- a/src/vm/page.c
+++ b/src/vm/page.c
@@ -122,7 +122,6 @@ bool pmap_writeback_pme_data (struct pme* e, const void* buffer) {
     {
       return false;
     }
-
   }
   return true;
 }
@@ -158,7 +157,7 @@ static void pmap_destroy_function (struct hash_elem *e, void *aux UNUSED){
   if( pme_target -> load_status == true ) {
     kaddr = pagedir_get_page( cur->pagedir, pme_target->vaddr );
     // NOTE : flush if dirty
-    ASSERT(pmap_flush_pme_data(pme_target, kaddr) == true);
+    ASSERT( pmap_flush_pme_data(pme_target, kaddr) == true );
 
     palloc_free_page( kaddr );
     pagedir_clear_page( cur->pagedir, pme_target->vaddr );

--- a/src/vm/page.h
+++ b/src/vm/page.h
@@ -19,7 +19,7 @@ struct pme {
                           // (false) otherwise
   bool write_permission;  // (true) if writable, (false) otherwise
 
-  pme_type type;          // { PME_EXEC, PME_MMAP, PME_SWAP }
+  pme_type type;          // { PME_EXEC, PME_MMAP, PME_SWAP, PME_NULL }
 
   // PME_EXEC related
   struct file* pme_exec_file;

--- a/src/vm/page.h
+++ b/src/vm/page.h
@@ -28,11 +28,18 @@ struct pme {
   size_t       pme_exec_read_bytes;
   size_t       pme_exec_zero_bytes;
 
-  // PME_MMAP related todo
+  // PME_MMAP related
+  struct file* pme_mmap_file;
+  int          pme_mmap_read_offset;
+  size_t       pme_mmap_read_bytes;
+  size_t       pme_mmap_zero_bytes;
 
   // PME_SWAP related todo
 
-  struct hash_elem elem;
+  struct hash_elem elem;          // used to insert to struct thread.pmap
+  /* === ADD START p3q3 ===*/
+  struct list_elem mmap_elem;     // used to insert to struct mmap_meta.pme_list
+  /* === ADD END p3q3 ===*/
 };
 
 // NOTE : pmap stands for pagemap,
@@ -44,7 +51,8 @@ void pmap_init (struct hash*);
 struct pme* pmap_get_pme (struct hash*, void* vaddr);
 
 bool pmap_set_pme (struct hash*, struct pme*);
-bool pmap_clear_pme (struct hash*, struct pme*);
+bool pmap_clear_pme (struct hash*, struct pme*, bool);
+bool pmap_flush_pme_data (struct pme*, const void*);
 
 static struct pme* lookup_pme (struct hash*, void*);
 

--- a/src/vm/page.h
+++ b/src/vm/page.h
@@ -34,7 +34,8 @@ struct pme {
   size_t       pme_mmap_read_bytes;
   size_t       pme_mmap_zero_bytes;
 
-  // PME_SWAP related todo
+  // PME_SWAP related
+  size_t       pme_swap_index;
 
   struct hash_elem elem;          // used to insert to struct thread.pmap
   /* === ADD START p3q3 ===*/
@@ -52,7 +53,8 @@ struct pme* pmap_get_pme (struct hash*, void* vaddr);
 
 bool pmap_set_pme (struct hash*, struct pme*);
 bool pmap_clear_pme (struct hash*, struct pme*, bool);
-bool pmap_flush_pme_data (struct pme*, const void*);
+bool pmap_flush_pme_data ( struct pme*, const void* );
+bool pmap_writeback_pme_data (struct pme*, const void* )
 
 static struct pme* lookup_pme (struct hash*, void*);
 

--- a/src/vm/page.h
+++ b/src/vm/page.h
@@ -54,7 +54,7 @@ struct pme* pmap_get_pme (struct hash*, void* vaddr);
 bool pmap_set_pme (struct hash*, struct pme*);
 bool pmap_clear_pme (struct hash*, struct pme*, bool);
 bool pmap_flush_pme_data ( struct pme*, const void* );
-bool pmap_writeback_pme_data (struct pme*, const void* )
+bool pmap_writeback_pme_data (struct pme*, const void* );
 
 static struct pme* lookup_pme (struct hash*, void*);
 

--- a/src/vm/page.h
+++ b/src/vm/page.h
@@ -6,10 +6,10 @@
 #include <hash.h>
 
 typedef enum _pme_type {
-    PME_EXEC = 0001,   // loading from executable
-    PME_MMAP = 0002,   // memory-mapped file
-    PME_SWAP = 0004,   // swap page
-    PME_NULL = 0000    // every other types, we basically don't care
+    PME_EXEC = 1,   // loading from executable
+    PME_MMAP = 2,   // memory-mapped file
+    PME_SWAP = 3,   // swap page
+    PME_NULL = 4    // every other types, we basically don't care
 } pme_type;
 
 // NOTE : pme stands for pagemap entry

--- a/src/vm/page.h
+++ b/src/vm/page.h
@@ -14,7 +14,8 @@ typedef enum _pme_type {
 
 // NOTE : pme stands for pagemap entry
 struct pme {
-  void *vaddr;
+  void *vaddr;            // Must be multiples of 4K
+                          // i.e. pg_round_down must be applied
   bool load_status;       // (true) if loaded to physical memory
                           // (false) otherwise
   bool write_permission;  // (true) if writable, (false) otherwise

--- a/src/vm/page.h
+++ b/src/vm/page.h
@@ -52,7 +52,7 @@ void pmap_init (struct hash*);
 struct pme* pmap_get_pme (struct hash*, void* vaddr);
 
 bool pmap_set_pme (struct hash*, struct pme*);
-bool pmap_clear_pme (struct hash*, struct pme*, bool);
+bool pmap_clear_pme (struct hash*, struct pme*);
 bool pmap_flush_pme_data ( struct pme*, const void* );
 bool pmap_writeback_pme_data (struct pme*, const void* );
 

--- a/src/vm/page.h
+++ b/src/vm/page.h
@@ -3,7 +3,7 @@
 #ifndef VM_PAGE_H
 #define VM_PAGE_H
 
-#include "<hash.h>"
+#include <hash.h>
 
 typedef enum _pme_type {
     PME_EXEC = 0001,   // loading from executable
@@ -39,8 +39,6 @@ struct pme {
 struct pme* create_pme ();
 
 void pmap_init (struct hash*);
-static unsigned pmap_hash_function (const struct hash_elem*, void* UNUSED);
-static bool pme_less (const struct hash_elem*, const struct hash_elem*, void* UNUSED);
 
 struct pme* pmap_get_pme (struct hash*, void* vaddr);
 
@@ -50,7 +48,6 @@ bool pmap_clear_pme (struct hash*, struct pme*);
 static struct pme* lookup_pme (struct hash*, void*);
 
 void pmap_destroy (struct hash*);
-static void pmap_destroy_function (struct hash_elem *e, void *aux UNUSED);
 
 bool load_segment_on_demand ( struct pme*, void* );
 

--- a/src/vm/page.h
+++ b/src/vm/page.h
@@ -1,0 +1,60 @@
+/* === ADD START p3q1 ===*/
+
+#ifndef VM_PAGE_H
+#define VM_PAGE_H
+
+#include "<hash.h>"
+
+typedef enum _pme_type {
+    PME_EXEC = 0001,   // loading from executable
+    PME_MMAP = 0002,   // memory-mapped file
+    PME_SWAP = 0004,   // swap page
+    PME_NULL = 0000    // every other types, we basically don't care
+} pme_type;
+
+// NOTE : pme stands for pagemap entry
+struct pme {
+  void *vaddr;
+  bool load_status;       // (true) if loaded to physical memory
+                          // (false) otherwise
+  bool write_permission;  // (true) if writable, (false) otherwise
+
+  pme_type type;          // { PME_EXEC, PME_MMAP, PME_SWAP }
+
+  // PME_EXEC related
+  struct file* pme_exec_file;
+  int          pme_exec_read_offset;
+  size_t       pme_exec_read_bytes;
+  size_t       pme_exec_zero_bytes;
+
+  // PME_MMAP related todo
+
+  // PME_SWAP related todo
+
+  struct hash_elem elem;
+};
+
+// NOTE : pmap stands for pagemap,
+//        which is the Supplementary Page Table
+struct pme* create_pme ();
+
+void pmap_init (struct hash*);
+static unsigned pmap_hash_function (const struct hash_elem*, void* UNUSED);
+static bool pme_less (const struct hash_elem*, const struct hash_elem*, void* UNUSED);
+
+struct pme* pmap_get_pme (struct hash*, void* vaddr);
+
+bool pmap_set_pme (struct hash*, struct pme*);
+bool pmap_clear_pme (struct hash*, struct pme*);
+
+static struct pme* lookup_pme (struct hash*, void*);
+
+void pmap_destroy (struct hash*);
+static void pmap_destroy_function (struct hash_elem *e, void *aux UNUSED);
+
+bool load_segment_on_demand ( struct pme*, void* );
+
+#endif /* vm/page.h */
+
+/* === ADD END p3q1 ===*/
+

--- a/src/vm/swap.c
+++ b/src/vm/swap.c
@@ -1,6 +1,7 @@
-/* === ADD START p3q3 ===*/
+/* === ADD START p3q4 ===*/
 #include "swap.h"
 
+// todo all
 
-/* === ADD END p3q3 ===*/
+/* === ADD END p3q4 ===*/
 

--- a/src/vm/swap.c
+++ b/src/vm/swap.c
@@ -1,14 +1,21 @@
 /* === ADD START p3q4 ===*/
 #include "swap.h"
 #include "devices/block.h"
+#include "threads/vaddr.h"
 
 
 static struct swap_table swap_table;
 
-void swap_table_init ( int swap_table_size ) {
+void swap_table_init ( ) {
+
+  // check if block driver works
+  struct block* block = block_get_role (BLOCK_SWAP);
+  ASSERT( block != NULL );
+
+  swap_table.size = block_size (block) / SECTORS_IN_PAGE ;
   lock_init( &(swap_table.lock) );
-  swap_table.used_map = bitmap_create ( swap_table_size );
-  swap_table.size = swap_table_size;
+  swap_table.used_map = bitmap_create ( swap_table.size );
+
 }
 
 void swap_in ( st_idx idx, void* kaddr ) {
@@ -51,10 +58,10 @@ st_idx swap_out ( const void* kaddr ) {
 //            if not, then this is write operation
 void execute_swap( st_idx idx, void* buffer, bool is_read ) {
 
-  struct block *block;
+  struct block* block;
   block = block_get_role (BLOCK_SWAP);
 
-  bl_idx block_start_idx = get_block_idx( st_idx );
+  bl_idx block_start_idx = get_block_idx( idx );
 
   bl_idx i;
   for( i = 0; i < BLOCKS_IN_PAGE ; i++ ) {
@@ -65,7 +72,6 @@ void execute_swap( st_idx idx, void* buffer, bool is_read ) {
       block_write (block, block_start_idx + i, buffer + BLOCK_SECTOR_SIZE * i);
     }
   }
-  return;
 }
 
 bl_idx get_block_idx( st_idx idx ) {
@@ -79,4 +85,3 @@ bool is_valid_idx( st_idx idx ){
 
 
 /* === ADD END p3q4 ===*/
-

--- a/src/vm/swap.c
+++ b/src/vm/swap.c
@@ -1,7 +1,82 @@
 /* === ADD START p3q4 ===*/
 #include "swap.h"
+#include "devices/block.h"
 
-// todo all
+
+static struct swap_table swap_table;
+
+void swap_table_init ( int swap_table_size ) {
+  lock_init( &(swap_table.lock) );
+  swap_table.used_map = bitmap_create ( swap_table_size );
+  swap_table.size = swap_table_size;
+}
+
+void swap_in ( st_idx idx, void* kaddr ) {
+
+  ASSERT( is_valid_idx(idx) );
+  ASSERT (pg_ofs (kaddr) == 0);
+
+  lock_acquire( &swap_table.lock );
+  // block read
+  execute_swap( idx, kaddr, true );
+  // swap clear
+  bitmap_set_multiple( swap_table.used_map, idx, 1, false );
+
+  lock_release( &swap_table.lock );
+}
+
+void swap_clear( st_idx idx ) {
+  ASSERT( is_valid_idx(idx) );
+  lock_acquire( &swap_table.lock );
+  bitmap_set_multiple( swap_table.used_map, idx, 1, false );
+  lock_release( &swap_table.lock );
+}
+
+st_idx swap_out ( const void* kaddr ) {
+  ASSERT (pg_ofs (kaddr) == 0);
+
+  lock_acquire( &swap_table.lock );
+  // fetch swap page
+  st_idx idx = bitmap_scan_and_flip( swap_table.used_map, 0, 1, false);
+  ASSERT( idx != BITMAP_ERROR );
+  // block write
+  execute_swap( idx, kaddr, false );
+
+  lock_release( &swap_table.lock );
+
+  return idx;
+}
+
+// NOTE : if is_read, then this is read operation
+//            if not, then this is write operation
+void execute_swap( st_idx idx, void* buffer, bool is_read ) {
+
+  struct block *block;
+  block = block_get_role (BLOCK_SWAP);
+
+  bl_idx block_start_idx = get_block_idx( st_idx );
+
+  bl_idx i;
+  for( i = 0; i < BLOCKS_IN_PAGE ; i++ ) {
+
+    if( is_read ){  // read
+      block_read (block, block_start_idx + i, buffer + BLOCK_SECTOR_SIZE * i);
+    } else {        // write
+      block_write (block, block_start_idx + i, buffer + BLOCK_SECTOR_SIZE * i);
+    }
+  }
+  return;
+}
+
+bl_idx get_block_idx( st_idx idx ) {
+  // scale index for BLOCKS_IN_PAGE_BITS times.
+  return idx << BLOCKS_IN_PAGE_BITS;
+}
+
+bool is_valid_idx( st_idx idx ){
+  return ( idx >= 0 && idx < swap_table.size);
+}
+
 
 /* === ADD END p3q4 ===*/
 

--- a/src/vm/swap.c
+++ b/src/vm/swap.c
@@ -1,0 +1,6 @@
+/* === ADD START p3q3 ===*/
+#include "swap.h"
+
+
+/* === ADD END p3q3 ===*/
+

--- a/src/vm/swap.h
+++ b/src/vm/swap.h
@@ -1,0 +1,10 @@
+/* === ADD START p3q3 ===*/
+#ifndef VM_SWAP_H
+#define VM_SWAP_H
+
+
+
+
+#endif //PINTOS_SWAP_H
+/* === ADD END p3q3 ===*/
+

--- a/src/vm/swap.h
+++ b/src/vm/swap.h
@@ -5,21 +5,27 @@
 #include <bitmap.h>
 #include "threads/synch.h"
 
+#define BLOCKS_IN_PAGE 8
+#define BLOCKS_IN_PAGE_BITS 3
 
 struct swap_table {
     struct bitmap*  used_map;
     struct lock     lock;
+    int             size;
 };
 
-static struct swap_table swap_table;
+typedef size_t st_idx;         // index type for swap table
+typedef size_t bl_idx;         // index type for block operation querying
 
-// todo all
+void swap_table_init ( int );
+void swap_in ( st_idx, void* );
+void swap_clear ( st_idx );
+swap_table_idx swap_out ( const void* );
 
+void execute_swap( st_idx, void*, bool );
 
-void swap_table_init ();
-void swap_in ();
-void swap_out ();
-
+bl_idx get_block_idx( st_idx );
+bool is_valid_idx( st_idx );
 
 #endif //PINTOS_SWAP_H
 /* === ADD END p3q4 ===*/

--- a/src/vm/swap.h
+++ b/src/vm/swap.h
@@ -4,9 +4,11 @@
 
 #include <bitmap.h>
 #include "threads/synch.h"
+#include "devices/block.h"
 
 #define BLOCKS_IN_PAGE 8
 #define BLOCKS_IN_PAGE_BITS 3
+#define SECTORS_IN_PAGE (PGSIZE / BLOCK_SECTOR_SIZE)
 
 struct swap_table {
     struct bitmap*  used_map;
@@ -17,10 +19,10 @@ struct swap_table {
 typedef size_t st_idx;         // index type for swap table
 typedef size_t bl_idx;         // index type for block operation querying
 
-void swap_table_init ( int );
+void swap_table_init ( );
 void swap_in ( st_idx, void* );
 void swap_clear ( st_idx );
-swap_table_idx swap_out ( const void* );
+st_idx swap_out ( const void* );
 
 void execute_swap( st_idx, void*, bool );
 

--- a/src/vm/swap.h
+++ b/src/vm/swap.h
@@ -1,10 +1,26 @@
-/* === ADD START p3q3 ===*/
+/* === ADD START p3q4 ===*/
 #ifndef VM_SWAP_H
 #define VM_SWAP_H
 
+#include <bitmap.h>
+#include "threads/synch.h"
 
+
+struct swap_table {
+    struct bitmap*  used_map;
+    struct lock     lock;
+};
+
+static struct swap_table swap_table;
+
+// todo all
+
+
+void swap_table_init ();
+void swap_in ();
+void swap_out ();
 
 
 #endif //PINTOS_SWAP_H
-/* === ADD END p3q3 ===*/
+/* === ADD END p3q4 ===*/
 


### PR DESCRIPTION
TOTAL TESTING SCORE: 100.0%
ALL TESTED PASSED -- PERFECT SCORE

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

SUMMARY BY TEST SET

Test Set                                      Pts Max  % Ttl  % Max
--------------------------------------------- --- --- ------ ------
tests/vm/Rubric.functionality                  55/ 55  50.0%/ 50.0%
tests/vm/Rubric.robustness                     28/ 28  15.0%/ 15.0%
tests/userprog/Rubric.functionality           108/108  10.0%/ 10.0%
tests/userprog/Rubric.robustness               88/ 88   5.0%/  5.0%
tests/filesys/base/Rubric                      30/ 30  20.0%/ 20.0%
--------------------------------------------- --- --- ------ ------
Total                                                 100.0%/100.0%

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

SUMMARY OF INDIVIDUAL TESTS

Functionality of virtual memory subsystem (tests/vm/Rubric.functionality):
        - Test stack growth.
             3/ 3 tests/vm/pt-grow-stack
             3/ 3 tests/vm/pt-grow-stk-sc
             3/ 3 tests/vm/pt-big-stk-obj
             3/ 3 tests/vm/pt-grow-pusha

        - Test paging behavior.
             3/ 3 tests/vm/page-linear
             3/ 3 tests/vm/page-parallel
             3/ 3 tests/vm/page-shuffle
             4/ 4 tests/vm/page-merge-seq
             4/ 4 tests/vm/page-merge-par
             4/ 4 tests/vm/page-merge-mm
             4/ 4 tests/vm/page-merge-stk

        - Test "mmap" system call.
             2/ 2 tests/vm/mmap-read
             2/ 2 tests/vm/mmap-write
             2/ 2 tests/vm/mmap-shuffle

             2/ 2 tests/vm/mmap-twice

             2/ 2 tests/vm/mmap-unmap
             1/ 1 tests/vm/mmap-exit

             3/ 3 tests/vm/mmap-clean

             2/ 2 tests/vm/mmap-close
             2/ 2 tests/vm/mmap-remove

        - Section summary.
             20/ 20 tests passed
             55/ 55 points subtotal

Robustness of virtual memory subsystem (tests/vm/Rubric.robustness):
        - Test robustness of page table support.
             2/ 2 tests/vm/pt-bad-addr
             3/ 3 tests/vm/pt-bad-read
             2/ 2 tests/vm/pt-write-code
             3/ 3 tests/vm/pt-write-code2
             4/ 4 tests/vm/pt-grow-bad

        - Test robustness of "mmap" system call.
             1/ 1 tests/vm/mmap-bad-fd
             1/ 1 tests/vm/mmap-inherit
             1/ 1 tests/vm/mmap-null
             1/ 1 tests/vm/mmap-zero

             2/ 2 tests/vm/mmap-misalign

             2/ 2 tests/vm/mmap-over-code
             2/ 2 tests/vm/mmap-over-data
             2/ 2 tests/vm/mmap-over-stk
             2/ 2 tests/vm/mmap-overlap


        - Section summary.
             14/ 14 tests passed
             28/ 28 points subtotal

Functionality of system calls (tests/userprog/Rubric.functionality):
        - Test argument passing on Pintos command line.
             3/ 3 tests/userprog/args-none
             3/ 3 tests/userprog/args-single
             3/ 3 tests/userprog/args-multiple
             3/ 3 tests/userprog/args-many
             3/ 3 tests/userprog/args-dbl-space

        - Test "create" system call.
             3/ 3 tests/userprog/create-empty
             3/ 3 tests/userprog/create-long
             3/ 3 tests/userprog/create-normal
             3/ 3 tests/userprog/create-exists

        - Test "open" system call.
             3/ 3 tests/userprog/open-missing
             3/ 3 tests/userprog/open-normal
             3/ 3 tests/userprog/open-twice

        - Test "read" system call.
             3/ 3 tests/userprog/read-normal
             3/ 3 tests/userprog/read-zero

        - Test "write" system call.
             3/ 3 tests/userprog/write-normal
             3/ 3 tests/userprog/write-zero

        - Test "close" system call.
             3/ 3 tests/userprog/close-normal

        - Test "exec" system call.
             5/ 5 tests/userprog/exec-once
             5/ 5 tests/userprog/exec-multiple
             5/ 5 tests/userprog/exec-arg

        - Test "wait" system call.
             5/ 5 tests/userprog/wait-simple
             5/ 5 tests/userprog/wait-twice

        - Test "exit" system call.
             5/ 5 tests/userprog/exit

        - Test "halt" system call.
             3/ 3 tests/userprog/halt

        - Test recursive execution of user programs.
            15/15 tests/userprog/multi-recurse

        - Test read-only executable feature.
             3/ 3 tests/userprog/rox-simple
             3/ 3 tests/userprog/rox-child
             3/ 3 tests/userprog/rox-multichild

        - Section summary.
             28/ 28 tests passed
            108/108 points subtotal

Robustness of system calls (tests/userprog/Rubric.robustness):
        - Test robustness of file descriptor handling.
             2/ 2 tests/userprog/close-stdin
             2/ 2 tests/userprog/close-stdout
             2/ 2 tests/userprog/close-bad-fd
             2/ 2 tests/userprog/close-twice
             2/ 2 tests/userprog/read-bad-fd
             2/ 2 tests/userprog/read-stdout
             2/ 2 tests/userprog/write-bad-fd
             2/ 2 tests/userprog/write-stdin
             2/ 2 tests/userprog/multi-child-fd

        - Test robustness of pointer handling.
             3/ 3 tests/userprog/create-bad-ptr
             3/ 3 tests/userprog/exec-bad-ptr
             3/ 3 tests/userprog/open-bad-ptr
             3/ 3 tests/userprog/read-bad-ptr
             3/ 3 tests/userprog/write-bad-ptr

        - Test robustness of buffer copying across page boundaries.
             3/ 3 tests/userprog/create-bound
             3/ 3 tests/userprog/open-boundary
             3/ 3 tests/userprog/read-boundary
             3/ 3 tests/userprog/write-boundary

        - Test handling of null pointer and empty strings.
             2/ 2 tests/userprog/create-null
             2/ 2 tests/userprog/open-null
             2/ 2 tests/userprog/open-empty

        - Test robustness of system call implementation.
             3/ 3 tests/userprog/sc-bad-arg
             3/ 3 tests/userprog/sc-bad-sp
             5/ 5 tests/userprog/sc-boundary
             5/ 5 tests/userprog/sc-boundary-2

        - Test robustness of "exec" and "wait" system calls.
             5/ 5 tests/userprog/exec-missing
             5/ 5 tests/userprog/wait-bad-pid
             5/ 5 tests/userprog/wait-killed

        - Test robustness of exception handling.
             1/ 1 tests/userprog/bad-read
             1/ 1 tests/userprog/bad-write
             1/ 1 tests/userprog/bad-jump
             1/ 1 tests/userprog/bad-read2
             1/ 1 tests/userprog/bad-write2
             1/ 1 tests/userprog/bad-jump2

        - Section summary.
             34/ 34 tests passed
             88/ 88 points subtotal

Functionality of base file system (tests/filesys/base/Rubric):
        - Test basic support for small files.
             1/ 1 tests/filesys/base/sm-create
             2/ 2 tests/filesys/base/sm-full
             2/ 2 tests/filesys/base/sm-random
             2/ 2 tests/filesys/base/sm-seq-block
             3/ 3 tests/filesys/base/sm-seq-random

        - Test basic support for large files.
             1/ 1 tests/filesys/base/lg-create
             2/ 2 tests/filesys/base/lg-full
             2/ 2 tests/filesys/base/lg-random
             2/ 2 tests/filesys/base/lg-seq-block
             3/ 3 tests/filesys/base/lg-seq-random

        - Test synchronized multiprogram access to files.
             4/ 4 tests/filesys/base/syn-read
             4/ 4 tests/filesys/base/syn-write
             2/ 2 tests/filesys/base/syn-remove

        - Section summary.
             13/ 13 tests passed
             30/ 30 points subtotal
